### PR TITLE
Uses settings.STATIC_URL for static files if it is defined

### DIFF
--- a/django_apistar/wsgi.py
+++ b/django_apistar/wsgi.py
@@ -36,7 +36,12 @@ class DjangoAPIStarWSGIApplication:
     def __call__(self, environ, start_response):
         path = environ['PATH_INFO']
 
-        if path.startswith('/static/'):
+        if settings.STATIC_URL is not None:
+            static_url = settings.STATIC_URL
+        else:
+            static_url = '/static/'
+
+        if path.startswith(static_url):
             return StaticFilesHandler(self.django_wsgi_app)(environ, start_response)
 
         if self.is_allowed_django_route(path):

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -88,6 +88,14 @@ class TestWSGIApp(TestCase):
         mocked_handler.assert_called_once_with(app.django_wsgi_app)
         mocked_handler().assert_called_once_with({'PATH_INFO': '/static/lulu'}, None)
 
+    @override_settings(STATIC_URL='/other_static/')
+    @patch('django_apistar.wsgi.StaticFilesHandler')
+    def test_calls_django_static_handler_if_path_startswith_different_static_url(self, mocked_handler):
+        app = wsgi.DjangoAPIStarWSGIApplication()
+        app({'PATH_INFO': '/other_static/lulu'}, None)
+        mocked_handler.assert_called_once_with(app.django_wsgi_app)
+        mocked_handler().assert_called_once_with({'PATH_INFO': '/other_static/lulu'}, None)
+
     @override_settings(APISTAR_SETTINGS={'ALLOWED_DJANGO_ROUTES': ('/fake/',)})
     @patch('django_apistar.wsgi.get_wsgi_application')
     def test_uses_django_app_if_route_is_allowed(self, mocked_get_app):


### PR DESCRIPTION
We don't just use it directly because it is defined by default in
django's `global_settings.py`[1] as None. In that case, se just use
`/static/` as before.

[1]: https://github.com/django/django/blob/master/django/conf/global_settings.py#L281